### PR TITLE
feat: add -v argument

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,15 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go-version: [1.18.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     name: lint
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,8 @@ builds:
     ldflags:
       - -s
       - -w
+      - -X github.com/madsaune/gorwos/pkg/version.Version={{.Version}}
+      - -X github.com/madsaune/gorwos/pkg/version.BuildDate={{.Date}}
     main: ./cmd
 archives:
   -

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,16 +7,23 @@ import (
 	"strings"
 
 	"github.com/madsaune/gorwos/pkg/gorwos"
+	"github.com/madsaune/gorwos/pkg/version"
 )
 
 var (
 	length        = flag.Int("l", 16, "length of string")
 	count         = flag.Int("c", 1, "number of passwords")
 	customOptions = flag.String("o", "ulds", "custom options (u, l, d, s, p, x")
+	showVersion   = flag.Bool("v", false, "show version")
 )
 
 func main() {
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Println(version.String())
+		return
+	}
 
 	opts := optionsFromArgs(*count, *length, *customOptions)
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,37 @@
+package version
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type Info struct {
+	Version   string
+	BuildDate string
+}
+
+// Version of afctl
+var Version = "dev"
+
+// BuildDate of the release
+var BuildDate = "unknown"
+
+func GetVersionInfo() Info {
+	return Info{
+		Version:   Version,
+		BuildDate: BuildDate,
+	}
+}
+
+func AsJSON() string {
+	if data, err := json.MarshalIndent(GetVersionInfo(), "", " "); err == nil {
+		return string(data)
+	}
+
+	return ""
+}
+
+func String() string {
+	v := GetVersionInfo()
+	return fmt.Sprintf("afctl version %s (%s)\n", v.Version, v.BuildDate)
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -10,7 +10,7 @@ type Info struct {
 	BuildDate string
 }
 
-// Version of afctl
+// Version of gorwos
 var Version = "dev"
 
 // BuildDate of the release
@@ -33,5 +33,5 @@ func AsJSON() string {
 
 func String() string {
 	v := GetVersionInfo()
-	return fmt.Sprintf("afctl version %s (%s)\n", v.Version, v.BuildDate)
+	return fmt.Sprintf("gorwos version %s (%s)\n", v.Version, v.BuildDate)
 }


### PR DESCRIPTION
This PR adds the `-v` flag to command to show version. Version is injected when built with goreleaser.